### PR TITLE
step 2 filter by orbital body

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,39 @@
+import { useState } from "react";
 import { Chart } from "./components/Chart";
 import { useFetchNeo } from "./hooks/useFetchNeo";
 
 export default function App() {
-  const { data, loading, error } = useFetchNeo();
+  const { data, bodies, loading, error } = useFetchNeo();
+  const [selectedBody, setSelectedBody] = useState("");
 
   if (loading) return <p className="text-center mt-10 text-lg">Loading...</p>;
   if (error) return <p className="text-center mt-10 text-red-500">{error}</p>;
 
+  const filteredData = selectedBody
+    ? data.filter((d) => d.orbitingBodies.includes(selectedBody))
+    : data;
+
   return (
     <div className="p-8 max-w-5xl mx-auto container">
-      <h1 className="text-3xl font-bold mb-6 text-center">Near Earth Objects (Diameter Overview)</h1>
-      <Chart data={data} />
+      <h1 className="text-3xl font-bold mb-6 text-center">Near Earth Objects</h1>
+
+      <div className="mb-6 flex justify-center">
+        <select
+          value={selectedBody}
+          onChange={(e) => setSelectedBody(e.target.value)}
+          className="border border-gray-300 rounded px-3 py-2 text-sm"
+        >
+          <option value="">All Orbital Bodies</option>
+          {bodies.map((body) => (
+            <option key={body} value={body}>
+              {body}
+            </option>
+          ))}
+        </select>
+      </div>
+
+
+      <Chart data={filteredData} />
     </div>
   );
 }

--- a/src/hooks/useFetchNeo.ts
+++ b/src/hooks/useFetchNeo.ts
@@ -5,6 +5,7 @@ import { NearEarthObject, Neo, ParsedNearEarthObject } from "../types/neo";
 
 export const useFetchNeo = () => {
   const [data, setData] = useState<ParsedNearEarthObject[]>([]);
+  const [bodies, setBodies] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -16,14 +17,25 @@ export const useFetchNeo = () => {
         const processed = json.near_earth_objects.map((neo) => {
           const min = neo.estimated_diameter.kilometers.estimated_diameter_min;
           const max = neo.estimated_diameter.kilometers.estimated_diameter_max;
+          const orbitingBodies = neo.close_approach_data?.map(
+            (entry) => entry.orbiting_body
+          ) || [];
+
           return {
             name: neo.name,
             minDiameter: min,
             maxDiameter: max,
-            avgDiameter: (min + max) / 2
+            avgDiameter: (min + max) / 2,
+            orbitingBodies: [...new Set(orbitingBodies)],
           };
-        }).sort((a, b) => b.avgDiameter - a.avgDiameter);
+        })
+        const allBodies = processed.flatMap((neo) => neo.orbitingBodies);
+        const uniqueBodies = Array.from(new Set(allBodies));
+
+        processed.sort((a, b) => b.avgDiameter - a.avgDiameter);
+
         setData(processed);
+        setBodies(uniqueBodies);
       } catch (err: any) {
         setError("Failed to fetch data.");
       } finally {
@@ -34,5 +46,5 @@ export const useFetchNeo = () => {
     fetchNeo();
   }, []);
 
-  return { data, loading, error };
+  return { data, loading, error, bodies };
 };

--- a/src/types/neo.ts
+++ b/src/types/neo.ts
@@ -5,6 +5,9 @@ export interface Neo {
 export interface NearEarthObject {
     name: string
     estimated_diameter: EstimatedDiameter
+    close_approach_data?: {
+        orbiting_body: string
+    }[]
 }
 
 export interface EstimatedDiameter {
@@ -38,5 +41,7 @@ export type ParsedNearEarthObject = {
     name: string,
     minDiameter: number,
     maxDiameter: number,
-    avgDiameter: number
+    avgDiameter: number,
+    orbitingBodies: string[];
+
 }  

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2015",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
- allow the user to choose to only display NEOs that are orbiting a certain orbital body

- The dropdown allows the user to select one orbital body name - if an orbital body is selected the chart only displays NEOs that are currently orbiting the selected body.